### PR TITLE
点击配置界面的WebUI 控制台可跳转插件界面

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,7 @@ export function initConfigUI(ctx: NapCatPluginContext) {
                 </div>
                 <div style="font-size: 13px; color: #4b5563;">
                     更多高级配置（浏览器路径、并发数、视口设置等）请前往 
-                    <a href="#" onclick="document.querySelector('[data-id=\\'napcat-plugin-puppeteer\\'] .plugin-console-btn').click(); return false;" style="color: #fb7299; text-decoration: none; font-weight: 600; transition: opacity 0.2s;">WebUI 控制台</a> 
+                    <a href="/plugin/napcat-plugin-puppeteer/page/puppeteer-dashboard" target="_top" style="color: #fb7299; text-decoration: none; font-weight: 600; transition: opacity 0.2s;">WebUI 控制台</a> 
                     进行管理。
                 </div>
             </div>


### PR DESCRIPTION
混个贡献

## Summary by Sourcery

增强：
- 将 WebUI 控制台 链接从页面内点击处理程序改为直接导航 URL，目标指向 puppeteer 仪表盘页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Change the WebUI 控制台 link from an in-page click handler to a direct navigation URL targeting the puppeteer dashboard page.

</details>