### PR TITLE
feat(browser): 添加浏览器代理配置功能 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ dist
 # 其他文件
 /.api-docs
 /.example
+
+.idea

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,12 +27,7 @@ export const DEFAULT_BROWSER_CONFIG: BrowserConfig = {
         '--disable-device-discovery-notifications',
         '--disable-accelerated-2d-canvas',
     ],
-    proxy: {
-        server: '',
-        username: '',
-        password: '',
-        bypassList: '',
-    },
+    proxy: undefined,
     maxPages: 10,
     timeout: 30000,
     defaultViewportWidth: 800,

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,12 @@ export const DEFAULT_BROWSER_CONFIG: BrowserConfig = {
         '--disable-device-discovery-notifications',
         '--disable-accelerated-2d-canvas',
     ],
+    proxy: {
+        server: '',
+        username: '',
+        password: '',
+        bypassList: '',
+    },
     maxPages: 10,
     timeout: 30000,
     defaultViewportWidth: 800,

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -72,6 +72,18 @@ function sanitizeConfig(raw: unknown): PluginConfig {
             browserConfig.deviceScaleFactor = b['deviceScaleFactor'];
         }
 
+        // proxy config
+        const rawProxy = b['proxy'];
+        if (isObject(rawProxy)) {
+            const proxy = rawProxy as Record<string, unknown>;
+            browserConfig.proxy = {
+                server: typeof proxy['server'] === 'string' ? proxy['server'] : undefined,
+                username: typeof proxy['username'] === 'string' ? proxy['username'] : undefined,
+                password: typeof proxy['password'] === 'string' ? proxy['password'] : undefined,
+                bypassList: typeof proxy['bypassList'] === 'string' ? proxy['bypassList'] : undefined,
+            };
+        }
+
         out.browser = browserConfig;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,8 +201,15 @@ export interface BrowserProxyConfig {
     /**
      * 代理 bypass 列表
      * 逗号分隔的域名列表，这些域名不走代理
-     * 例如: localhost,127.0.0.1,.local
      */
+    bypassList?: string;
+}
+
+/**
+ * 浏览器状态中暴露的代理配置（不含敏感信息）
+ */
+export interface BrowserStatusProxy {
+    server: string;
     bypassList?: string;
 }
 
@@ -308,8 +315,8 @@ export interface BrowserStatus {
     executablePath?: string;
     /** 远程浏览器地址（远程模式） */
     browserWSEndpoint?: string;
-    /** 代理服务器配置 */
-    proxy?: BrowserProxyConfig;
+    /** 代理服务器配置（不含敏感信息） */
+    proxy?: BrowserStatusProxy;
     /** 启动时间 */
     startTime?: number;
     /** 总渲染次数 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,35 @@ export interface RenderResult<T extends Encoding = 'base64', M extends MultiPage
 // ==================== 浏览器配置 ====================
 
 /**
+ * 浏览器代理配置
+ */
+export interface BrowserProxyConfig {
+    /**
+     * 代理服务器地址
+     * 格式: protocol://host:port
+     * 例如: http://127.0.0.1:7890, socks5://127.0.0.1:1080
+     */
+    server?: string;
+
+    /**
+     * 代理用户名（可选，用于认证代理）
+     */
+    username?: string;
+
+    /**
+     * 代理密码（可选，用于认证代理）
+     */
+    password?: string;
+
+    /**
+     * 代理 bypass 列表
+     * 逗号分隔的域名列表，这些域名不走代理
+     * 例如: localhost,127.0.0.1,.local
+     */
+    bypassList?: string;
+}
+
+/**
  * 浏览器启动配置
  */
 export interface BrowserConfig {
@@ -206,6 +235,13 @@ export interface BrowserConfig {
      * 浏览器启动参数
      */
     args?: string[];
+
+    /**
+     * 代理服务器配置
+     * 用于国内机器访问国外网站时走代理
+     * 注意：远程模式（browserWSEndpoint）下此配置不生效
+     */
+    proxy?: BrowserProxyConfig;
 
     /**
      * 最大并发页面数
@@ -272,6 +308,8 @@ export interface BrowserStatus {
     executablePath?: string;
     /** 远程浏览器地址（远程模式） */
     browserWSEndpoint?: string;
+    /** 代理服务器配置 */
+    proxy?: BrowserProxyConfig;
     /** 启动时间 */
     startTime?: number;
     /** 总渲染次数 */

--- a/src/webui/src/pages/SettingsPage.tsx
+++ b/src/webui/src/pages/SettingsPage.tsx
@@ -52,8 +52,8 @@ const defaultSettings = {
     proxyBypassList: '',
 }
 
-export default function SettingsPage() {
-    const [config, setConfig] = useState({
+function getInitialConfig() {
+    return {
         maxPages: defaultSettings.maxPages,
         lockTimeout: defaultSettings.lockTimeout,
         executablePath: '',
@@ -69,7 +69,31 @@ export default function SettingsPage() {
         proxyUsername: '',
         proxyPassword: '',
         proxyBypassList: '',
-    })
+    }
+}
+
+function getResetConfig() {
+    return {
+        maxPages: defaultSettings.maxPages,
+        lockTimeout: defaultSettings.lockTimeout,
+        executablePath: '',
+        browserWSEndpoint: '',
+        browserArgs: '',
+        headless: true,
+        defaultWidth: defaultSettings.defaultWidth,
+        defaultHeight: defaultSettings.defaultHeight,
+        defaultScale: defaultSettings.defaultScale,
+        debug: false,
+        autoStart: defaultSettings.autoStart,
+        proxyServer: '',
+        proxyUsername: '',
+        proxyPassword: '',
+        proxyBypassList: '',
+    }
+}
+
+export default function SettingsPage() {
+    const [config, setConfig] = useState(getInitialConfig())
 
     const [status, setStatus] = useState<ChromeStatus | null>(null)
     const [version, setVersion] = useState('')
@@ -220,23 +244,7 @@ export default function SettingsPage() {
             showToast('正在恢复默认配置...', 'info')
 
             // 设置本地状态为默认值
-            const newConfig = {
-                maxPages: defaultSettings.maxPages,
-                lockTimeout: defaultSettings.lockTimeout,
-                executablePath: '',
-                browserWSEndpoint: '',
-                browserArgs: '',
-                headless: true,
-                defaultWidth: defaultSettings.defaultWidth,
-                defaultHeight: defaultSettings.defaultHeight,
-                defaultScale: defaultSettings.defaultScale,
-                debug: false,
-                autoStart: defaultSettings.autoStart,
-                proxyServer: '',
-                proxyUsername: '',
-                proxyPassword: '',
-                proxyBypassList: '',
-            }
+            const newConfig = getResetConfig()
             setConfig(newConfig)
 
             try {

--- a/src/webui/src/pages/SettingsPage.tsx
+++ b/src/webui/src/pages/SettingsPage.tsx
@@ -1,8 +1,20 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { Globe, Image, Settings as SettingsIcon, AlertCircle, Download, Check, Info, Monitor, Server, Trash2, Lock } from 'lucide-react'
-import { authFetch, noAuthFetch } from '../utils/api'
-import { showToast } from '../hooks/useToast'
-import type { PluginConfig, ChromeStatus, ChromeProgress } from '../types'
+ import {useState, useEffect, useCallback, useRef} from 'react'
+import {
+    Globe,
+    Image,
+    Settings as SettingsIcon,
+    AlertCircle,
+    Download,
+    Check,
+    Info,
+    Monitor,
+    Server,
+    Trash2,
+    Lock
+} from 'lucide-react'
+import {authFetch, noAuthFetch} from '../utils/api'
+import {showToast} from '../hooks/useToast'
+import type {PluginConfig, ChromeStatus, ChromeProgress} from '../types'
 
 // 默认浏览器启动参数（与后端 DEFAULT_BROWSER_CONFIG.args 保持一致）
 const defaultBrowserArgs = [
@@ -117,7 +129,7 @@ export default function SettingsPage() {
         }
     }
 
-const loadSettings = useCallback(async () => {
+    const loadSettings = useCallback(async () => {
         try {
             const data = await authFetch<PluginConfig>('/config')
             if (data.code === 0 && data.data) {
@@ -150,7 +162,7 @@ const loadSettings = useCallback(async () => {
         loadChromeStatus()
     }, [loadSettings, loadChromeStatus])
 
-const saveSettings = useCallback(async (showSuccess = true) => {
+    const saveSettings = useCallback(async (showSuccess = true) => {
         try {
             const configData = {
                 enabled: config.autoStart,
@@ -193,7 +205,7 @@ const saveSettings = useCallback(async (showSuccess = true) => {
     }, [saveSettings])
 
     const updateConfig = <K extends keyof typeof config>(key: K, value: typeof config[K]) => {
-        setConfig(prev => ({ ...prev, [key]: value }))
+        setConfig(prev => ({...prev, [key]: value}))
     }
 
     // 监听配置变化，自动保存
@@ -201,7 +213,7 @@ const saveSettings = useCallback(async (showSuccess = true) => {
         debounceSave()
     }, [config, debounceSave])
 
-const handleResetClick = async () => {
+    const handleResetClick = async () => {
         if (showResetConfirm) {
             // 第二次点击，执行重置
             setShowResetConfirm(false)
@@ -262,7 +274,7 @@ const handleResetClick = async () => {
     const installChrome = async () => {
         try {
             showToast('正在启动安装...', 'info')
-            setProgress({ status: 'downloading', progress: 0, message: '准备中...' })
+            setProgress({status: 'downloading', progress: 0, message: '准备中...'})
             setIsInstalling(true)
 
             const data = await authFetch('/chrome/install', {
@@ -293,7 +305,7 @@ const handleResetClick = async () => {
             setShowUninstallConfirm(false)
             showToast('正在卸载 Chrome...', 'info')
             try {
-                const data = await authFetch('/chrome/uninstall', { method: 'POST' })
+                const data = await authFetch('/chrome/uninstall', {method: 'POST'})
                 const success = data.code === 0
                 showToast(data.message || (success ? '卸载成功' : '卸载失败'), success ? 'success' : 'error')
                 // 卸载后刷新状态
@@ -322,7 +334,7 @@ const handleResetClick = async () => {
             {/* Browser Settings */}
             <div className="bg-white dark:bg-[#1a1b1d] rounded-lg border border-gray-200 dark:border-gray-800 p-6">
                 <div className="flex items-center gap-3 mb-6 border-b border-gray-100 dark:border-gray-800 pb-4">
-                    <Globe size={20} className="text-gray-900 dark:text-gray-100" />
+                    <Globe size={20} className="text-gray-900 dark:text-gray-100"/>
                     <div>
                         <h3 className="font-bold text-base text-gray-900 dark:text-white">浏览器设置</h3>
                         <p className="text-xs text-gray-500 mt-0.5">Puppeteer 实例与连接配置</p>
@@ -332,7 +344,8 @@ const handleResetClick = async () => {
                 <div className="space-y-5">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                         <div>
-                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">最大页面数</label>
+                            <label
+                                className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">最大页面数</label>
                             <input
                                 type="number"
                                 value={config.maxPages}
@@ -347,7 +360,9 @@ const handleResetClick = async () => {
                             </p>
                         </div>
                         <div>
-                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">超时时间 (ms)</label>
+                            <label
+                                className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">超时时间
+                                (ms)</label>
                             <input
                                 type="number"
                                 value={config.lockTimeout}
@@ -363,7 +378,8 @@ const handleResetClick = async () => {
                     </div>
 
                     <div>
-                        <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">本地浏览器路径</label>
+                        <label
+                            className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">本地浏览器路径</label>
                         <input
                             type="text"
                             value={config.executablePath}
@@ -377,7 +393,9 @@ const handleResetClick = async () => {
                     </div>
 
                     <div>
-                        <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">远程浏览器地址 (WebSocket)</label>
+                        <label
+                            className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">远程浏览器地址
+                            (WebSocket)</label>
                         <input
                             type="text"
                             value={config.browserWSEndpoint}
@@ -390,8 +408,9 @@ const handleResetClick = async () => {
                         </p>
                     </div>
 
-<div>
-                        <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">启动参数</label>
+                    <div>
+                        <label
+                            className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">启动参数</label>
                         <input
                             type="text"
                             value={config.browserArgs}
@@ -405,12 +424,14 @@ const handleResetClick = async () => {
                     {/* Proxy Settings */}
                     <div className="mt-6 pt-4 border-t border-gray-100 dark:border-gray-800">
                         <div className="flex items-center gap-2 mb-4">
-                            <Lock size={14} className="text-gray-400" />
-                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">代理服务器配置</span>
+                            <Lock size={14} className="text-gray-400"/>
+                            <span
+                                className="text-xs font-semibold text-gray-500 uppercase tracking-wider">代理服务器配置</span>
                         </div>
                         <div className="space-y-4">
                             <div>
-                                <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理服务器地址</label>
+                                <label
+                                    className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理服务器地址</label>
                                 <input
                                     type="text"
                                     value={config.proxyServer}
@@ -424,7 +445,8 @@ const handleResetClick = async () => {
                             </div>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <div>
-                                    <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理用户名</label>
+                                    <label
+                                        className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理用户名</label>
                                     <input
                                         type="text"
                                         value={config.proxyUsername}
@@ -434,7 +456,8 @@ const handleResetClick = async () => {
                                     />
                                 </div>
                                 <div>
-                                    <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理密码</label>
+                                    <label
+                                        className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">代理密码</label>
                                     <input
                                         type="password"
                                         value={config.proxyPassword}
@@ -445,7 +468,9 @@ const handleResetClick = async () => {
                                 </div>
                             </div>
                             <div>
-                                <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">Bypass 列表</label>
+                                <label
+                                    className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">Bypass
+                                    列表</label>
                                 <input
                                     type="text"
                                     value={config.proxyBypassList}
@@ -460,7 +485,8 @@ const handleResetClick = async () => {
                         </div>
                     </div>
 
-                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
+                    <div
+                        className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
                         <div>
                             <div className="font-medium text-sm text-gray-900 dark:text-gray-200">无头模式</div>
                             <div className="text-xs text-gray-500">隐藏浏览器窗口运行</div>
@@ -480,7 +506,7 @@ const handleResetClick = async () => {
             {/* Render Defaults */}
             <div className="bg-white dark:bg-[#1a1b1d] rounded-lg border border-gray-200 dark:border-gray-800 p-6">
                 <div className="flex items-center gap-3 mb-6 border-b border-gray-100 dark:border-gray-800 pb-4">
-                    <Image size={20} className="text-gray-900 dark:text-gray-100" />
+                    <Image size={20} className="text-gray-900 dark:text-gray-100"/>
                     <div>
                         <h3 className="font-bold text-base text-gray-900 dark:text-white">渲染默认值</h3>
                         <p className="text-xs text-gray-500 mt-0.5">截图渲染的默认参数</p>
@@ -490,7 +516,8 @@ const handleResetClick = async () => {
                 <div className="space-y-4">
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div>
-                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">默认宽度</label>
+                            <label
+                                className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">默认宽度</label>
                             <input
                                 type="number"
                                 value={config.defaultWidth}
@@ -501,7 +528,8 @@ const handleResetClick = async () => {
                             />
                         </div>
                         <div>
-                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">默认高度</label>
+                            <label
+                                className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">默认高度</label>
                             <input
                                 type="number"
                                 value={config.defaultHeight}
@@ -512,7 +540,8 @@ const handleResetClick = async () => {
                             />
                         </div>
                         <div>
-                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">设备缩放</label>
+                            <label
+                                className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">设备缩放</label>
                             <input
                                 type="number"
                                 value={config.defaultScale}
@@ -531,7 +560,7 @@ const handleResetClick = async () => {
             {/* Other Settings */}
             <div className="bg-white dark:bg-[#1a1b1d] rounded-lg border border-gray-200 dark:border-gray-800 p-6">
                 <div className="flex items-center gap-3 mb-6 border-b border-gray-100 dark:border-gray-800 pb-4">
-                    <SettingsIcon size={20} className="text-gray-900 dark:text-gray-100" />
+                    <SettingsIcon size={20} className="text-gray-900 dark:text-gray-100"/>
                     <div>
                         <h3 className="font-bold text-base text-gray-900 dark:text-white">其他设置</h3>
                         <p className="text-xs text-gray-500 mt-0.5">调试与高级选项</p>
@@ -539,7 +568,8 @@ const handleResetClick = async () => {
                 </div>
 
                 <div className="space-y-3">
-                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
+                    <div
+                        className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
                         <div>
                             <div className="font-medium text-sm text-gray-900 dark:text-gray-200">调试模式</div>
                             <div className="text-xs text-gray-500">启用后输出详细日志到控制台</div>
@@ -554,7 +584,8 @@ const handleResetClick = async () => {
                         </label>
                     </div>
 
-                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
+                    <div
+                        className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
                         <div>
                             <div className="font-medium text-sm text-gray-900 dark:text-gray-200">自动启动浏览器</div>
                             <div className="text-xs text-gray-500">插件加载时自动启动浏览器实例</div>
@@ -570,7 +601,8 @@ const handleResetClick = async () => {
                     </div>
 
                     {/* 重置配置 */}
-                    <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
+                    <div
+                        className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
                         <div>
                             <div className="font-medium text-sm text-gray-900 dark:text-gray-200">重置配置</div>
                             <div className="text-xs text-gray-500">恢复所有设置为默认值</div>
@@ -580,10 +612,10 @@ const handleResetClick = async () => {
                             className={`btn text-xs px-3 py-1.5 border shadow-none transition-all ${showResetConfirm
                                 ? 'bg-red-600 hover:bg-red-700 text-white border-red-600 animate-pulse'
                                 : 'bg-red-50 hover:bg-red-100 dark:bg-red-900/10 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 border-red-200 dark:border-red-900/30'
-                                }`}
+                            }`}
                             title="恢复所有设置为默认值"
                         >
-                            <AlertCircle size={14} className="mr-1.5 inline" />
+                            <AlertCircle size={14} className="mr-1.5 inline"/>
                             {showResetConfirm ? '再次点击确认重置' : '重置配置'}
                         </button>
                     </div>
@@ -592,9 +624,10 @@ const handleResetClick = async () => {
 
             {/* Chrome Setup */}
             <div className="bg-white dark:bg-[#1a1b1d] rounded-lg border border-gray-200 dark:border-gray-800 p-6">
-                <div className="flex items-center justify-between mb-6 border-b border-gray-100 dark:border-gray-800 pb-4">
+                <div
+                    className="flex items-center justify-between mb-6 border-b border-gray-100 dark:border-gray-800 pb-4">
                     <div className="flex items-center gap-3">
-                        <Download size={20} className="text-gray-900 dark:text-gray-100" />
+                        <Download size={20} className="text-gray-900 dark:text-gray-100"/>
                         <div>
                             <h3 className="font-bold text-base text-gray-900 dark:text-white">环境管理</h3>
                             <p className="text-xs text-gray-500 mt-0.5">
@@ -612,10 +645,10 @@ const handleResetClick = async () => {
                             className={`btn text-xs px-3 py-1.5 border shadow-none transition-all ${showUninstallConfirm
                                 ? 'bg-red-600 hover:bg-red-700 text-white border-red-600 animate-pulse'
                                 : 'bg-red-50 hover:bg-red-100 dark:bg-red-900/10 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 border-red-200 dark:border-red-900/30'
-                                }`}
+                            }`}
                             title="卸载内置 Chrome（如果浏览器损坏可尝试此操作）"
                         >
-                            <Trash2 size={14} className="mr-1.5" />
+                            <Trash2 size={14} className="mr-1.5"/>
                             {showUninstallConfirm ? '再次点击确认卸载' : '卸载 Chrome'}
                         </button>
                     )}
@@ -625,7 +658,7 @@ const handleResetClick = async () => {
                 {status?.installedBrowsers && status.installedBrowsers.length > 0 && (
                     <div className="mb-4">
                         <label className="text-[10px] font-semibold text-gray-500 uppercase mb-2 block tracking-wider">
-                            <Monitor size={12} className="inline mr-1 mb-0.5" />
+                            <Monitor size={12} className="inline mr-1 mb-0.5"/>
                             系统已安装的浏览器
                         </label>
                         <div className="space-y-2">
@@ -635,25 +668,29 @@ const handleResetClick = async () => {
                                     className="p-3 bg-gray-50 dark:bg-[#202124] rounded-lg border border-gray-200 dark:border-gray-700 flex items-center justify-between group hover:border-primary/50 transition-colors"
                                 >
                                     <div className="flex items-center gap-3">
-                                        <div className={`w-8 h-8 rounded-lg flex items-center justify-center text-white text-xs font-bold shadow-sm ${browser.type === 'chrome' ? 'bg-[#4285F4]' :
-                                            browser.type === 'edge' ? 'bg-[#0078D7]' :
-                                                browser.type === 'brave' ? 'bg-[#FF5500]' :
-                                                    'bg-gray-500'
+                                        <div
+                                            className={`w-8 h-8 rounded-lg flex items-center justify-center text-white text-xs font-bold shadow-sm ${browser.type === 'chrome' ? 'bg-[#4285F4]' :
+                                                browser.type === 'edge' ? 'bg-[#0078D7]' :
+                                                    browser.type === 'brave' ? 'bg-[#FF5500]' :
+                                                        'bg-gray-500'
                                             }`}>
                                             {browser.type === 'chrome' ? 'C' :
                                                 browser.type === 'edge' ? 'E' :
                                                     browser.type === 'brave' ? 'B' : 'Cr'}
                                         </div>
                                         <div>
-                                            <div className="font-medium text-sm capitalize text-gray-900 dark:text-gray-200">
+                                            <div
+                                                className="font-medium text-sm capitalize text-gray-900 dark:text-gray-200">
                                                 {browser.type}
                                                 {browser.channel !== 'stable' && (
-                                                    <span className="ml-2 px-1.5 py-0.5 text-[10px] bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded font-bold uppercase">
+                                                    <span
+                                                        className="ml-2 px-1.5 py-0.5 text-[10px] bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded font-bold uppercase">
                                                         {browser.channel}
                                                     </span>
                                                 )}
                                             </div>
-                                            <div className="text-xs text-gray-500 font-mono truncate max-w-[300px]" title={browser.executablePath}>
+                                            <div className="text-xs text-gray-500 font-mono truncate max-w-[300px]"
+                                                 title={browser.executablePath}>
                                                 {browser.executablePath}
                                             </div>
                                         </div>
@@ -685,7 +722,7 @@ const handleResetClick = async () => {
                     <div className={`flex gap-2 text-sm ${status?.canInstall
                         ? 'text-blue-700 dark:text-blue-300'
                         : 'text-amber-700 dark:text-amber-300'}`}>
-                        <Info size={16} className="flex-shrink-0 mt-0.5" />
+                        <Info size={16} className="flex-shrink-0 mt-0.5"/>
                         <div>
                             <p className="font-bold text-xs uppercase tracking-wide mb-1">环境说明</p>
                             <p className={`text-xs leading-relaxed ${status?.canInstall
@@ -694,8 +731,8 @@ const handleResetClick = async () => {
                                 {status?.canInstall ? (
                                     <>
                                         检测到 {status?.platform === 'win32'
-                                            ? (status?.windowsVersion ? status.windowsVersion : 'Windows')
-                                            : status?.platform === 'darwin' ? 'macOS' : 'Linux'}
+                                        ? (status?.windowsVersion ? status.windowsVersion : 'Windows')
+                                        : status?.platform === 'darwin' ? 'macOS' : 'Linux'}
                                         {status?.linuxDistro ? ` (${status.linuxDistro})` : ''} 环境，
                                         支持自动下载安装 Chrome for Testing。
                                         如果您使用远程浏览器或已配置本地 Chrome 路径，无需使用此功能。
@@ -712,19 +749,22 @@ const handleResetClick = async () => {
 
                 {/* 远程浏览器推荐 */}
                 {!status?.canInstall && (
-                    <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/10 rounded-md border border-green-100 dark:border-green-900/20">
+                    <div
+                        className="mb-4 p-4 bg-green-50 dark:bg-green-900/10 rounded-md border border-green-100 dark:border-green-900/20">
                         <div className="flex gap-3">
-                            <Server size={18} className="text-green-600 dark:text-green-500 flex-shrink-0 mt-0.5" />
+                            <Server size={18} className="text-green-600 dark:text-green-500 flex-shrink-0 mt-0.5"/>
                             <div>
                                 <p className="font-bold text-xs uppercase tracking-wide mb-1 text-green-700 dark:text-green-300">推荐：使用远程浏览器</p>
                                 <p className="text-xs mt-1 text-green-600 dark:text-green-400 leading-relaxed">
                                     您可以使用 Docker 运行一个独立的 Chrome 容器，然后通过 WebSocket 连接：
                                 </p>
-                                <div className="mt-2 p-2 bg-gray-900 rounded text-xs font-mono text-green-400 overflow-x-auto border border-gray-800">
+                                <div
+                                    className="mt-2 p-2 bg-gray-900 rounded text-xs font-mono text-green-400 overflow-x-auto border border-gray-800">
                                     docker run -d --name chrome -p 3000:3000 browserless/chrome
                                 </div>
                                 <p className="text-xs mt-2 text-green-600 dark:text-green-400">
-                                    然后在上方「远程浏览器地址」填入：<code className="px-1 py-0.5 bg-green-100 dark:bg-green-900/30 rounded font-bold">ws://localhost:3000</code>
+                                    然后在上方「远程浏览器地址」填入：<code
+                                    className="px-1 py-0.5 bg-green-100 dark:bg-green-900/30 rounded font-bold">ws://localhost:3000</code>
                                 </p>
                             </div>
                         </div>
@@ -736,7 +776,9 @@ const handleResetClick = async () => {
                     <div className="space-y-4 pt-4 border-t border-gray-100 dark:border-gray-800">
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div>
-                                <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">Chrome 版本</label>
+                                <label
+                                    className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">Chrome
+                                    版本</label>
                                 <input
                                     type="text"
                                     value={version}
@@ -746,7 +788,8 @@ const handleResetClick = async () => {
                                 />
                             </div>
                             <div>
-                                <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">下载源</label>
+                                <label
+                                    className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">下载源</label>
                                 <select
                                     value={source}
                                     onChange={(e) => setSource(e.target.value)}
@@ -756,14 +799,17 @@ const handleResetClick = async () => {
                                     <option value="NPMMIRROR_REGISTRY">淘宝源 Registry (备用)</option>
                                     <option value="GOOGLE">Google 官方源</option>
                                 </select>
-                                <div className="text-xs text-gray-400 mt-1">国内用户推荐使用 NPM 镜像源，下载速度更快</div>
+                                <div className="text-xs text-gray-400 mt-1">国内用户推荐使用 NPM 镜像源，下载速度更快
+                                </div>
                             </div>
                         </div>
 
                         {status?.platform === 'linux' && (
-                            <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
+                            <div
+                                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-[#202124] rounded-md border border-gray-100 dark:border-gray-800">
                                 <div>
-                                    <div className="font-medium text-sm text-gray-900 dark:text-gray-200">安装系统依赖</div>
+                                    <div className="font-medium text-sm text-gray-900 dark:text-gray-200">安装系统依赖
+                                    </div>
                                     <div className="text-xs text-gray-500">自动安装 Chrome 运行所需的系统库</div>
                                 </div>
                                 <label className="toggle-switch scale-90 origin-right">
@@ -778,20 +824,24 @@ const handleResetClick = async () => {
                         )}
 
                         {(isInstalling || progress) && progress?.status !== 'idle' && (
-                            <div className="p-4 bg-gray-50 dark:bg-black/20 rounded-lg border border-gray-100 dark:border-gray-800">
+                            <div
+                                className="p-4 bg-gray-50 dark:bg-black/20 rounded-lg border border-gray-100 dark:border-gray-800">
                                 <div className="mb-2 flex justify-between text-xs font-medium">
-                                    <span className="text-gray-600 dark:text-gray-400">{progress?.message || '处理中...'}</span>
-                                    <span className="font-mono text-primary">{Math.round(progress?.progress || 0)}%</span>
+                                    <span
+                                        className="text-gray-600 dark:text-gray-400">{progress?.message || '处理中...'}</span>
+                                    <span
+                                        className="font-mono text-primary">{Math.round(progress?.progress || 0)}%</span>
                                 </div>
                                 <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
                                     <div
                                         className={`h-2 rounded-full transition-all duration-300 ${getProgressColor()}`}
-                                        style={{ width: `${progress?.progress || 0}%` }}
+                                        style={{width: `${progress?.progress || 0}%`}}
                                     ></div>
                                 </div>
                                 {progress?.downloadedBytes && progress?.totalBytes && (
                                     <div className="mt-2 text-xs text-gray-500 font-mono">
-                                        {(progress.downloadedBytes / 1024 / 1024).toFixed(2)} MB / {(progress.totalBytes / 1024 / 1024).toFixed(2)} MB
+                                        {(progress.downloadedBytes / 1024 / 1024).toFixed(2)} MB
+                                        / {(progress.totalBytes / 1024 / 1024).toFixed(2)} MB
                                         {progress.speed && ` | ${progress.speed}`}
                                         {progress.eta && ` | 剩余 ${progress.eta}`}
                                     </div>
@@ -801,8 +851,9 @@ const handleResetClick = async () => {
 
                         <div className="flex gap-3 pt-2">
                             {status?.installed ? (
-                                <div className="flex-1 p-3 bg-green-50 dark:bg-green-900/10 rounded-md border border-green-200 dark:border-green-800 text-center text-sm font-medium text-green-700 dark:text-green-300 flex items-center justify-center gap-2">
-                                    <Check size={16} />
+                                <div
+                                    className="flex-1 p-3 bg-green-50 dark:bg-green-900/10 rounded-md border border-green-200 dark:border-green-800 text-center text-sm font-medium text-green-700 dark:text-green-300 flex items-center justify-center gap-2">
+                                    <Check size={16}/>
                                     Chrome 已安装 ({status.version})
                                 </div>
                             ) : (
@@ -811,7 +862,7 @@ const handleResetClick = async () => {
                                     disabled={isInstalling}
                                     className="btn btn-primary flex-1 disabled:opacity-50 text-sm font-medium py-2.5 shadow-sm"
                                 >
-                                    <Download size={16} />
+                                    <Download size={16}/>
                                     立即安装 Chrome
                                 </button>
                             )}

--- a/src/webui/src/pages/StatusPage.tsx
+++ b/src/webui/src/pages/StatusPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Play, RotateCcw, Square, Shield, CheckCircle, XCircle, Globe, Laptop } from 'lucide-react'
+import { Play, RotateCcw, Square, Shield, CheckCircle, XCircle, Globe, Laptop, Lock } from 'lucide-react'
 import type { PluginStatus } from '../types'
 import { authFetch } from '../utils/api'
 import { showToast } from '../hooks/useToast'
@@ -167,6 +167,34 @@ export default function StatusPage({ status, onRefresh }: StatusPageProps) {
                             {browser?.mode === 'remote' ? browser?.browserWSEndpoint : browser?.executablePath || '-'}
                         </span>
                     </div>
+
+                    {/* Proxy Info - Always show */}
+                    <div className="flex justify-between p-3 bg-gray-50 dark:bg-[#1a1b1d] rounded-lg border border-gray-100 dark:border-gray-800">
+                        <span className="text-gray-500 flex items-center gap-1">
+                            <Lock size={12} />
+                            代理服务器
+                        </span>
+                        <span
+                            className={`font-medium truncate font-mono text-xs ${browser?.proxy?.server ? 'text-gray-800 dark:text-gray-200' : 'text-gray-400'}`}
+                            title={browser?.proxy?.server}
+                        >
+                            {browser?.proxy?.server || '未配置'}
+                        </span>
+                    </div>
+                    {browser?.proxy?.server && (
+                        <div className="flex justify-between p-3 bg-gray-50 dark:bg-[#1a1b1d] rounded-lg border border-gray-100 dark:border-gray-800">
+                            <span className="text-gray-500 flex items-center gap-1">
+                                <Globe size={12} />
+                                Bypass 列表
+                            </span>
+                            <span
+                                className="font-medium truncate font-mono text-xs text-gray-800 dark:text-gray-200"
+                                title={browser?.proxy?.bypassList}
+                            >
+                                {browser?.proxy?.bypassList || '-'}
+                            </span>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/webui/src/pages/TestPage.tsx
+++ b/src/webui/src/pages/TestPage.tsx
@@ -126,7 +126,7 @@ export default function TestPage() {
                 </div>
 
                 <div className="flex-1 overflow-y-auto p-4 space-y-4 custom-scrollbar">
-{/* Type Select */}
+                    {/* Type Select */}
                     <div>
                         <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">渲染类型</label>
                         <select

--- a/src/webui/src/pages/TestPage.tsx
+++ b/src/webui/src/pages/TestPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Play, ChevronDown, Type } from 'lucide-react'
+import { Play, ChevronDown, Type, Globe } from 'lucide-react'
 import { noAuthFetch } from '../utils/api'
 import { showToast } from '../hooks/useToast'
 import type { RenderOptions } from '../types'
@@ -13,6 +13,14 @@ const defaultHtml = `<html>
   </div>
 </body>
 </html>`
+
+// 预设测试 URL
+const presetUrls = [
+    { label: 'Google 搜索', url: 'https://www.google.com' },
+    { label: 'Google 图片', url: 'https://www.google.com/search?q=cat&tbm=isch' },
+    { label: 'GitHub', url: 'https://github.com' },
+    { label: 'Bing', url: 'https://www.bing.com' },
+]
 
 export default function TestPage() {
     const [testType, setTestType] = useState<'html' | 'url'>('html')
@@ -118,7 +126,7 @@ export default function TestPage() {
                 </div>
 
                 <div className="flex-1 overflow-y-auto p-4 space-y-4 custom-scrollbar">
-                    {/* Type Select */}
+{/* Type Select */}
                     <div>
                         <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider">渲染类型</label>
                         <select
@@ -130,6 +138,30 @@ export default function TestPage() {
                             <option value="url">URL 地址</option>
                         </select>
                     </div>
+
+                    {/* Preset URLs (only for URL type) */}
+                    {testType === 'url' && (
+                        <div>
+                            <label className="text-[10px] font-semibold text-gray-500 uppercase mb-1.5 block tracking-wider flex items-center gap-1">
+                                <Globe size={12} />
+                                快速测试
+                            </label>
+                            <div className="flex flex-wrap gap-2">
+                                {presetUrls.map((preset) => (
+                                    <button
+                                        key={preset.url}
+                                        onClick={() => setContent(preset.url)}
+                                        className="text-xs px-2 py-1.5 bg-gray-100 dark:bg-gray-800 hover:bg-primary hover:text-white dark:hover:bg-primary border border-gray-200 dark:border-gray-700 rounded-md transition-colors"
+                                    >
+                                        {preset.label}
+                                    </button>
+                                ))}
+                            </div>
+                            <p className="text-[10px] text-gray-400 mt-1.5">
+                                点击按钮快速填充 URL，可用于测试代理是否生效
+                            </p>
+                        </div>
+                    )}
 
                     {/* Content */}
                     <div className="flex flex-col">

--- a/src/webui/src/types.ts
+++ b/src/webui/src/types.ts
@@ -8,7 +8,6 @@ export interface BrowserStatus {
     mode?: 'local' | 'remote'
     proxy?: {
         server?: string
-        username?: string
         bypassList?: string
     }
     totalRenders: number

--- a/src/webui/src/types.ts
+++ b/src/webui/src/types.ts
@@ -6,6 +6,11 @@ export interface BrowserStatus {
     executablePath?: string
     browserWSEndpoint?: string
     mode?: 'local' | 'remote'
+    proxy?: {
+        server?: string
+        username?: string
+        bypassList?: string
+    }
     totalRenders: number
     failedRenders: number
 }
@@ -23,6 +28,13 @@ export interface ApiResponse<T = unknown> {
     time?: number
 }
 
+export interface BrowserProxyConfig {
+    server?: string
+    username?: string
+    password?: string
+    bypassList?: string
+}
+
 export interface PluginConfig {
     enabled: boolean
     debug: boolean
@@ -36,6 +48,7 @@ export interface PluginConfig {
         defaultViewportWidth: number
         defaultViewportHeight: number
         deviceScaleFactor: number
+        proxy?: BrowserProxyConfig
     }
 }
 


### PR DESCRIPTION
- 在配置文件中添加代理服务器设置选项
- 添加代理认证（用户名密码）
- 添加代理 bypass 列表配置
- 在状态页面显示当前代理配置信息
- 在测试页面添加预设URL，快速测试功能
- 更新WebUI界面添加代理配置表单
- 添加代理配置后，需到仪表盘进行重启

## Summary by Sourcery

为插件添加可配置的浏览器代理支持，并在 Web 界面中展示其状态。

新功能：
- 允许在浏览器设置界面和插件配置中设置浏览器代理服务器、认证信息以及绕过列表。
- 在浏览器状态页面显示当前代理服务器和绕过列表。
- 在测试页面提供预设测试 URL，以便快速验证浏览器/代理的连通性。

增强改进：
- 扩展 Puppeteer 的启动和页面获取逻辑，以遵循配置的代理设置，包括绕过列表和可选的基础认证。
- 在后端对代理配置进行清洗和持久化存储，并通过浏览器状态 API 暴露非敏感的代理信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable browser proxy support to the plugin and surface its status in the Web UI.

New Features:
- Allow configuring browser proxy server, authentication, and bypass list in the browser settings UI and plugin configuration.
- Display current proxy server and bypass list in the browser status page.
- Provide preset test URLs in the test page to quickly verify browser/proxy connectivity.

Enhancements:
- Extend Puppeteer launch and page acquisition logic to respect configured proxy settings, including bypass list and optional basic authentication.
- Sanitize and persist proxy configuration on the backend and expose non-sensitive proxy information via browser status APIs.

</details>